### PR TITLE
Change release trigger

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,7 @@
 name: Release
 on:
   release:
-    types: [edited]
+    types: [published]
   workflow_dispatch:
     inputs:
       TAG_NAME:


### PR DESCRIPTION
nit: Shouldn't we use the `published` event instead of the `edited` one? We could legitimately want to edit a past release and not want to run the release workflow again.

I think this event is properly triggered when publishing a draft.

cc @YiMysty 