### PR TITLE
Rename to include "GitHub" in "GitHub Pages" for Marketplace

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,4 +1,4 @@
-name: 'Configure Pages'
+name: 'Configure GitHub Pages'
 description: 'A GitHub Action to enable Pages, extract various metadata about a site, and configure some supported static site generators.'
 author: 'GitHub'
 runs:


### PR DESCRIPTION
Upon recommendation from `@chrispat`, we should rename our published Action's name to include "GitHub" in "GitHub Pages" on the Marketplace.