### PR TITLE
Update major version only on full releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,7 @@
 name: Release
 on:
   release:
-    types: [published]
+    types: [released]
   workflow_dispatch:
     inputs:
       TAG_NAME:


### PR DESCRIPTION
The `edited` event will trigger whenever the text, etc. is updated, even if the release is not published yet.

The `published` event will trigger for both release and pre-release publishing, so that is not ideal either.

Looks like the best option is the `released` event.

https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#release