### PR TITLE
Expand Prettier usage

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,6 +1,6 @@
 ---
-name-template: "v$RESOLVED_VERSION"
-tag-template: "v$RESOLVED_VERSION"
+name-template: 'v$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
 template: |
   # Changelog
 
@@ -8,33 +8,33 @@ template: |
 
   See details of [all code changes](https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION) since previous release.
 categories:
-  - title: "🚀 Features"
+  - title: '🚀 Features'
     labels:
-      - "feature"
-      - "enhancement"
-  - title: "🐛 Bug Fixes"
+      - 'feature'
+      - 'enhancement'
+  - title: '🐛 Bug Fixes'
     labels:
-      - "fix"
-      - "bugfix"
-      - "bug"
-  - title: "🧰 Maintenance"
+      - 'fix'
+      - 'bugfix'
+      - 'bug'
+  - title: '🧰 Maintenance'
     labels:
-      - "infrastructure"
-      - "automation"
-      - "documentation"
-  - title: "🏎 Performance"
-    label: "performance"
-change-template: "- $TITLE @$AUTHOR (#$NUMBER)"
+      - 'infrastructure'
+      - 'automation'
+      - 'documentation'
+  - title: '🏎 Performance'
+    label: 'performance'
+change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
 version-resolver:
   major:
     labels:
-      - "type: breaking"
+      - 'type: breaking'
   minor:
     labels:
-      - "type: enhancement"
+      - 'type: enhancement'
   patch:
     labels:
-      - "type: bug"
-      - "type: maintenance"
-      - "type: documentation"
+      - 'type: bug'
+      - 'type: maintenance'
+      - 'type: documentation'
   default: patch

--- a/.github/workflows/check-formatting.yml
+++ b/.github/workflows/check-formatting.yml
@@ -1,4 +1,4 @@
-name: Checking formatting
+name: Check formatting
 
 on:
   push:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
     inputs:
       TAG_NAME:
-        description: "Tag name that the major tag will point to"
+        description: 'Tag name that the major tag will point to'
         required: true
 
 env:

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,5 @@
+# Ignore build artifacts
+/dist/
+
+# Ignore all Markdown files
+*.md

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "description": "A GitHub Action to enable Pages and extract various metadata about a site. It can also be used to configure various static site generators we support as starter workflows.",
   "main": "./dist/index.js",
   "scripts": {
-    "format": "prettier --write 'src/**/*.js'",
-    "format:check": "prettier --check 'src/**/*.js'",
+    "format": "prettier --write .",
+    "format:check": "prettier --check .",
     "prepare": "npm run format && ncc build src/index.js -o dist --source-map --license licenses.txt",
     "test": "jest"
   },

--- a/src/fixtures/next/default.cjs
+++ b/src/fixtures/next/default.cjs
@@ -1,7 +1,7 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
-  swcMinify: true,
+  swcMinify: true
 }
 
 module.exports = nextConfig

--- a/src/fixtures/next/default.mjs
+++ b/src/fixtures/next/default.mjs
@@ -1,7 +1,7 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
-  swcMinify: true,
+  swcMinify: true
 }
 
 export default nextConfig

--- a/src/fixtures/nuxt/async.cjs
+++ b/src/fixtures/nuxt/async.cjs
@@ -1,15 +1,15 @@
-const getAllDynamicRoute = async function() {
+const getAllDynamicRoute = async function () {
   const routes = await (async () => {
-    return ['/posts/hello-world', '/posts/hello-again'];
-  })();
-  return routes;
-};
+    return ['/posts/hello-world', '/posts/hello-again']
+  })()
+  return routes
+}
 
 module.exports = {
   mode: 'universal',
   generate: {
-    async routes () {
-      return getAllDynamicRoute();
+    async routes() {
+      return getAllDynamicRoute()
     }
   }
-};
+}

--- a/src/fixtures/nuxt/async.expected.cjs
+++ b/src/fixtures/nuxt/async.expected.cjs
@@ -1,17 +1,17 @@
-const getAllDynamicRoute = async function() {
+const getAllDynamicRoute = async function () {
   const routes = await (async () => {
-    return ['/posts/hello-world', '/posts/hello-again'];
-  })();
-  return routes;
-};
+    return ['/posts/hello-world', '/posts/hello-again']
+  })()
+  return routes
+}
 
 module.exports = {
   target: 'static',
   router: { base: '/docs/' },
   mode: 'universal',
   generate: {
-    async routes () {
-      return getAllDynamicRoute();
+    async routes() {
+      return getAllDynamicRoute()
     }
   }
-};
+}

--- a/src/fixtures/nuxt/async.expected.mjs
+++ b/src/fixtures/nuxt/async.expected.mjs
@@ -1,17 +1,17 @@
-const getAllDynamicRoute = async function() {
+const getAllDynamicRoute = async function () {
   const routes = await (async () => {
-    return ['/posts/hello-world', '/posts/hello-again'];
-  })();
-  return routes;
-};
+    return ['/posts/hello-world', '/posts/hello-again']
+  })()
+  return routes
+}
 
 export default {
   target: 'static',
   router: { base: '/docs/' },
   mode: 'universal',
   generate: {
-    async routes () {
-      return getAllDynamicRoute();
+    async routes() {
+      return getAllDynamicRoute()
     }
   }
-};
+}

--- a/src/fixtures/nuxt/async.mjs
+++ b/src/fixtures/nuxt/async.mjs
@@ -1,15 +1,15 @@
-const getAllDynamicRoute = async function() {
+const getAllDynamicRoute = async function () {
   const routes = await (async () => {
-    return ['/posts/hello-world', '/posts/hello-again'];
-  })();
-  return routes;
-};
+    return ['/posts/hello-world', '/posts/hello-again']
+  })()
+  return routes
+}
 
 export default {
   mode: 'universal',
   generate: {
-    async routes () {
-      return getAllDynamicRoute();
+    async routes() {
+      return getAllDynamicRoute()
     }
   }
-};
+}

--- a/src/fixtures/nuxt/default.cjs
+++ b/src/fixtures/nuxt/default.cjs
@@ -14,9 +14,7 @@ module.exports = {
       { hid: 'description', name: 'description', content: '' },
       { name: 'format-detection', content: 'telephone=no' }
     ],
-    link: [
-      { rel: 'icon', type: 'image/x-icon', href: '/favicon.ico' }
-    ]
+    link: [{ rel: 'icon', type: 'image/x-icon', href: '/favicon.ico' }]
   },
 
   // Global CSS: https://go.nuxtjs.dev/config-css

--- a/src/fixtures/nuxt/default.expected.cjs
+++ b/src/fixtures/nuxt/default.expected.cjs
@@ -16,9 +16,7 @@ module.exports = {
       { hid: 'description', name: 'description', content: '' },
       { name: 'format-detection', content: 'telephone=no' }
     ],
-    link: [
-      { rel: 'icon', type: 'image/x-icon', href: '/favicon.ico' }
-    ]
+    link: [{ rel: 'icon', type: 'image/x-icon', href: '/favicon.ico' }]
   },
 
   // Global CSS: https://go.nuxtjs.dev/config-css

--- a/src/fixtures/nuxt/default.expected.mjs
+++ b/src/fixtures/nuxt/default.expected.mjs
@@ -16,9 +16,7 @@ export default {
       { hid: 'description', name: 'description', content: '' },
       { name: 'format-detection', content: 'telephone=no' }
     ],
-    link: [
-      { rel: 'icon', type: 'image/x-icon', href: '/favicon.ico' }
-    ]
+    link: [{ rel: 'icon', type: 'image/x-icon', href: '/favicon.ico' }]
   },
 
   // Global CSS: https://go.nuxtjs.dev/config-css

--- a/src/fixtures/nuxt/default.mjs
+++ b/src/fixtures/nuxt/default.mjs
@@ -14,9 +14,7 @@ export default {
       { hid: 'description', name: 'description', content: '' },
       { name: 'format-detection', content: 'telephone=no' }
     ],
-    link: [
-      { rel: 'icon', type: 'image/x-icon', href: '/favicon.ico' }
-    ]
+    link: [{ rel: 'icon', type: 'image/x-icon', href: '/favicon.ico' }]
   },
 
   // Global CSS: https://go.nuxtjs.dev/config-css


### PR DESCRIPTION
Allow for Prettier to reformat `*.yml`, `*.yaml`, `*.cjs`, `*.mjs`, etc. in addition to `*.js` as before -- but still exclude `*.md`.