### PR TITLE
Fix nextjs images.unoptimized config path name

### DIFF
--- a/src/set-pages-config.js
+++ b/src/set-pages-config.js
@@ -34,7 +34,7 @@ function getConfigParserSettings({ staticSiteGenerator, generatorConfigFile, sit
 
           // Disable server side image optimization too
           // https://nextjs.org/docs/api-reference/next/image#unoptimized
-          'experimental.images.unoptimized': true
+          'images.unoptimized': true
         }
       }
     case 'gatsby':

--- a/src/set-pages-config.js
+++ b/src/set-pages-config.js
@@ -34,6 +34,7 @@ function getConfigParserSettings({ staticSiteGenerator, generatorConfigFile, sit
 
           // Disable server side image optimization too
           // https://nextjs.org/docs/api-reference/next/image#unoptimized
+          'experimental.images.unoptimized': true,
           'images.unoptimized': true
         }
       }

--- a/src/set-pages-config.js
+++ b/src/set-pages-config.js
@@ -35,6 +35,7 @@ function getConfigParserSettings({ staticSiteGenerator, generatorConfigFile, sit
           // Disable server side image optimization too
           // https://nextjs.org/docs/api-reference/next/image#unoptimized
           'experimental.images.unoptimized': true,
+          // No longer experimental as of Next.js v12.3.0
           'images.unoptimized': true
         }
       }


### PR DESCRIPTION
`images.unoptimized` is stable with NextJS `v12.3.0`.

https://nextjs.org/docs/api-reference/next/image#unoptimized