### PR TITLE
add support to Nuxt3

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -6,7 +6,7 @@ runs:
   main: 'dist/index.js'
 inputs:
   static_site_generator:
-    description: 'Optional static site generator to attempt to configure: "nuxt", "next", "gatsby", or "sveltekit"'
+    description: 'Optional static site generator to attempt to configure: "nuxt", "nuxt3", "next", "gatsby", or "sveltekit"'
     required: false
   generator_config_file:
     description: 'Optional file path to static site generator configuration file'

--- a/src/blank-configurations/nuxt3.ts
+++ b/src/blank-configurations/nuxt3.ts
@@ -1,0 +1,3 @@
+// Default Pages configuration for Nuxt3
+// https://nuxt.com/docs/api/configuration/nuxt-config
+export default defineNuxtConfig({})

--- a/src/fixtures/nuxt3/async.expected.ts
+++ b/src/fixtures/nuxt3/async.expected.ts
@@ -1,3 +1,4 @@
+// https://nuxt.com/docs/api/configuration/nuxt-config
 const getAllDynamicRoute = async function () {
   const routes = await (async () => {
     return ['/posts/hello-world', '/posts/hello-again']
@@ -6,11 +7,9 @@ const getAllDynamicRoute = async function () {
 }
 
 export default defineNuxtConfig({
-  app: {
-    baseURL: '/docs/' 
-  },
+  ssr: false,
+  app: { baseURL: '/docs/' },
   generate: {
     routes: await getAllDynamicRoute()
   },
-  ssr: false
 })

--- a/src/fixtures/nuxt3/async.expected.ts
+++ b/src/fixtures/nuxt3/async.expected.ts
@@ -1,0 +1,16 @@
+const getAllDynamicRoute = async function () {
+  const routes = await (async () => {
+    return ['/posts/hello-world', '/posts/hello-again']
+  })()
+  return routes
+}
+
+export default defineNuxtConfig({
+  app: {
+    baseURL: '/docs/' 
+  },
+  generate: {
+    routes: await getAllDynamicRoute()
+  },
+  ssr: false
+})

--- a/src/fixtures/nuxt3/async.ts
+++ b/src/fixtures/nuxt3/async.ts
@@ -1,0 +1,12 @@
+const getAllDynamicRoute = async function () {
+  const routes = await (async () => {
+    return ['/posts/hello-world', '/posts/hello-again']
+  })()
+  return routes
+}
+
+export default defineNuxtConfig({
+  generate: {
+    routes: await getAllDynamicRoute()
+  }
+})

--- a/src/fixtures/nuxt3/async.ts
+++ b/src/fixtures/nuxt3/async.ts
@@ -1,3 +1,4 @@
+// https://nuxt.com/docs/api/configuration/nuxt-config
 const getAllDynamicRoute = async function () {
   const routes = await (async () => {
     return ['/posts/hello-world', '/posts/hello-again']

--- a/src/fixtures/nuxt3/default.expected.ts
+++ b/src/fixtures/nuxt3/default.expected.ts
@@ -1,0 +1,25 @@
+// https://nuxt.com/docs/api/configuration/nuxt-config
+export default defineNuxtConfig({
+  app: {
+    baseURL: '/docs/' ,
+    head: {
+      title: 'nuxt',
+      htmlAttrs: {
+        lang: 'en'
+      },
+      meta: [
+        { charset: 'utf-8' },
+        { name: 'viewport', content: 'width=device-width, initial-scale=1' },
+        { key: 'description', name: 'description', content: '' },
+        { name: 'format-detection', content: 'telephone=no' }
+      ],
+      link: [{ rel: 'icon', type: 'image/x-icon', href: '/favicon.ico' }]
+    }
+  },
+  ssr: false,
+  css: [],
+  plugins: [],
+  components: true,
+  modules: [],
+  build: {}
+})

--- a/src/fixtures/nuxt3/default.expected.ts
+++ b/src/fixtures/nuxt3/default.expected.ts
@@ -1,5 +1,6 @@
 // https://nuxt.com/docs/api/configuration/nuxt-config
 export default defineNuxtConfig({
+  ssr: false,
   app: {
     baseURL: '/docs/' ,
     head: {
@@ -16,7 +17,6 @@ export default defineNuxtConfig({
       link: [{ rel: 'icon', type: 'image/x-icon', href: '/favicon.ico' }]
     }
   },
-  ssr: false,
   css: [],
   plugins: [],
   components: true,

--- a/src/fixtures/nuxt3/default.ts
+++ b/src/fixtures/nuxt3/default.ts
@@ -1,0 +1,23 @@
+// https://nuxt.com/docs/api/configuration/nuxt-config
+export default defineNuxtConfig({
+  app: {
+    head: {
+      title: 'nuxt',
+      htmlAttrs: {
+        lang: 'en'
+      },
+      meta: [
+        { charset: 'utf-8' },
+        { name: 'viewport', content: 'width=device-width, initial-scale=1' },
+        { key: 'description', name: 'description', content: '' },
+        { name: 'format-detection', content: 'telephone=no' }
+      ],
+      link: [{ rel: 'icon', type: 'image/x-icon', href: '/favicon.ico' }]
+    }
+  },
+  css: [],
+  plugins: [],
+  components: true,
+  modules: [],
+  build: {}
+})

--- a/src/set-pages-config.js
+++ b/src/set-pages-config.js
@@ -23,6 +23,18 @@ function getConfigParserSettings({ staticSiteGenerator, generatorConfigFile, sit
           target: 'static'
         }
       }
+    case 'nuxt3':
+      return {
+        configurationFile: generatorConfigFile || './nuxt.config.ts',
+        blankConfigurationFile: `${__dirname}/blank-configurations/nuxt3.ts`,
+        properties: {
+          // Configure a base path of the app
+          'app.baseURL': path,
+
+          // Set the target to static too
+          ssr: false
+        }
+      }
     case 'next':
       // Next does not want a trailing slash
       path = removeTrailingSlash(path)

--- a/src/set-pages-config.js
+++ b/src/set-pages-config.js
@@ -27,6 +27,7 @@ function getConfigParserSettings({ staticSiteGenerator, generatorConfigFile, sit
       return {
         configurationFile: generatorConfigFile || './nuxt.config.ts',
         blankConfigurationFile: `${__dirname}/blank-configurations/nuxt3.ts`,
+        allowWrappingCall: true,
         properties: {
           // Configure a base path of the app
           'app.baseURL': path,

--- a/src/set-pages-config.test.js
+++ b/src/set-pages-config.test.js
@@ -8,8 +8,8 @@ const { getTempFolder, compareFiles } = require('./test-helpers')
 // Get the temp folder
 const tempFolder = getTempFolder()
 
-const SUPPORTED_GENERATORS = ['next', 'nuxt', 'gatsby', 'sveltekit']
-const SUPPORTED_FILE_EXTENSIONS = ['.js', '.cjs', '.mjs']
+const SUPPORTED_GENERATORS = ['next', 'nuxt', 'nuxt3', 'gatsby', 'sveltekit']
+const SUPPORTED_FILE_EXTENSIONS = ['.js', '.cjs', '.mjs', '.ts']
 const IS_BLANK_CONFIG_FILE_REGEX = new RegExp(
   '^blank\\.(' + SUPPORTED_FILE_EXTENSIONS.map(ext => ext.slice(1)).join('|') + ')$'
 )


### PR DESCRIPTION
This PR tries to allow Nuxt3's config file `nuxt.config.ts`. However, it uses Typescript, which looks like not being supported by now.
I've completed the function and test. If there's anything I should modify, please let me know!

As TypeScript files aren't really supported (say if you write `as NuxtConfig` at the end, it's not going to recognize your config), I'm not modifying [SUPPORTED_FILE_EXTENSIONS in set-pages-config.js](https://github.com/actions/configure-pages/blob/e5c1ee9f14eaedeb0a9c0155cfc4b80122cfd6ed/src/set-pages-config.js#L5). However, there's a need to modify those in other files for usual configs to work.

So, what is a currently accepted one? Well, if we type only key and values and don't write any type annotations, it's going to be fine.
Althought this may sounds silly since we are losing a huge functionality of TypeScript, I believe that kind of usage is really rare.

close #74 