### PR TITLE
Change throw statement to use Error object

### DIFF
--- a/src/set-pages-config.js
+++ b/src/set-pages-config.js
@@ -83,7 +83,7 @@ function getConfigParserSettings({ staticSiteGenerator, generatorConfigFile, sit
         }
       }
     default:
-      throw `Unsupported static site generator: ${staticSiteGenerator}`
+      throw new Error(`Unsupported static site generator: ${staticSiteGenerator}`)
   }
 }
 


### PR DESCRIPTION
I'm getting an error in my pipeline "Error: TypeError: error must be an instance of Error" which I believe is related to this line of code.